### PR TITLE
Fix 2.4.1 wal dir config

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,7 +7,7 @@ loki_group:  loki
 loki_base_dir: /opt/loki
 loki_dir: "{{ loki_base_dir }}"
 loki_config_dir: /etc/loki
-loki_version: "2.3.0"
+loki_version: "2.4.1"
 
 architecture_map:
   amd64: amd64
@@ -29,3 +29,6 @@ promtail_dist_url: "https://github.com/grafana/loki/releases/download/v{{ loki_v
 promtail_dist_location: "{{ loki_base_dir }}/promtail-linux-{{ package_architecture }}.zip"
 
 loki_enable_ruler: false
+
+loki_wal_enabled: true
+loki_wal_dir: "/var/lib/loki/wal"

--- a/tasks/tasks_loki.yml
+++ b/tasks/tasks_loki.yml
@@ -50,6 +50,18 @@
     tags:
       - loki
 
+  - name: Loki | Ensure wal folder
+    file:
+      path: "{{ loki_wal_dir }}"
+      state: "directory"
+      owner: "{{ loki_user }}"
+      group: "{{ loki_group }}"
+      mode: '0755'
+    become: yes
+    when: loki_wal_enabled|bool
+    tags:
+      - loki
+
   - name: Loki | Download distribution
     get_url:
       url: "{{ loki_dist_url }}"

--- a/templates/config-loki.yml.j2
+++ b/templates/config-loki.yml.j2
@@ -14,6 +14,9 @@ ingester:
   chunk_idle_period: 5m
   chunk_retain_period: 30s
   max_transfer_retries: 0
+  wal:
+    enabled: {{ loki_wal_enabled }}
+    dir: {{ loki_wal_dir }}
 
 schema_config:
   configs:


### PR DESCRIPTION
Hi @Voronenko , loki 2.4.1 enables wal but doesn't set the dir:

* https://github.com/grafana/loki/issues/2018
* https://issueexplorer.com/issue/grafana/loki/4647
* https://issueexplorer.com/issue/grafana/loki/4715

This fix allows the installation of 2.4.1 without problems.

Best regards
Sebastian